### PR TITLE
Fixed query string if it is empty.

### DIFF
--- a/directives/query/acendaQueryBuilder.js
+++ b/directives/query/acendaQueryBuilder.js
@@ -413,6 +413,9 @@ angular.module("app.directives")
                     if(value == '{}') {
                         value = "";
                     }
+                    if(value == '""') {
+                        value = "";
+                    }
                     $scope.querymodel = value;
 
                 }


### PR DESCRIPTION
Fixed query string if it is empty, it was creating a query of double quotes.
