### PR TITLE
Product admin history

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -13603,3 +13603,46 @@ h8 {
 
 }
 
+
+.changelog-table{
+    table-layout: fixed;
+    width:100%;
+}
+
+.changelog-table thead, .changelog-table tbody tr {
+    display:table;
+    width:100%;
+    table-layout:fixed;/* even columns width , fix width of table too*/
+}
+
+.changelog-table tbody{
+    display:block;
+    width:100%;
+    max-height: 400px;
+    overflow: auto;
+}
+
+.changelog-table td:nth-child(1),
+.changelog-table th:nth-child(1),
+{
+    width:120px;
+    max-width:150px;
+}                
+.changelog-table th:nth-child(2),
+.changelog-table td:nth-child(2)
+{
+    width:150px;
+    word-break: break-all
+}
+
+.changelog-table td > div{
+    word-wrap: break-word;
+    min-height: 1.5em;
+    max-height: 150px;
+    overflow: auto;
+    border: 1px solid #CBD5DD;
+    background-color: white;
+}
+.changelog-table a{
+    font-size: smaller;
+}

--- a/styles/main.css
+++ b/styles/main.css
@@ -7575,7 +7575,9 @@ td,th {
   }
 
   .ui-checkbox input[type="checkbox"] {
-    display: none;
+    /*display: none;*/
+    opacity: 0;
+    position: absolute;
   }
 
   .ui-checkbox input[type="checkbox"]+span {


### PR DESCRIPTION
Change Log section has been added to the bottom of these sections:

Product > Products
Product > Products > Variants > Edit an existing variant
Customer > Customers > Edit Information
Marketing > Coupons
Content > Content Editor

Click the Load button to load the change log for the section you're in.

In the Customer section when you edit info it creates a dialog instead of a new page. Saving the dialog will intentionally close the Change Log which can then be re-loaded.

Some fields are not saved in the changelog. Make sure that all fields that do get saved in it are well formed. For example, a changelog that shows oldvalue and newvalue both blank is broken and shouldn't show up. A changelog that shows unreadable info should also not be there.

Most changelog entries should have an Apply button beneath them to instantly apply that value to the field in the page. It should then scroll/focus to that field. Then the page would need to be re-saved to save that change.

Three repos:
https://github.com/torreycommerce/acendaAdminAngular/tree/product-admin-history
https://github.com/torreycommerce/acenda/tree/product-admin-history
https://github.com/torreycommerce/acenda_angular_common_resources/tree/product-admin-history